### PR TITLE
Update .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,4 @@ mouseovertooltip.min.js
 mouseovertooltipStyle.min.css
 dev/
 introduce/
+dev_bak


### PR DESCRIPTION
https://developers.google.com/datastudio/visualization/changelog#2021-02-10
With this update, type NUMBER can no longer be used with the SELECT_SINGLE.
This is a .gitignore file fix to prepare for that.