### PR TITLE
Support Google Data Studio's Changes to Style Configurations. 

### DIFF
--- a/en/mouseovertooltip.json
+++ b/en/mouseovertooltip.json
@@ -1,7 +1,7 @@
 {
   "data": [{
     "id": "setdummy",
-    "heading": "SetDummyData",
+    "label": "SetDummyData",
     "elements": []
   }],
   "style": [{
@@ -10,17 +10,18 @@
     "elements": [{
       "id": "tooltiptext",
       "label": "Text",
-      "type": "TEXTAREA"
+      "type": "TEXTAREA",
+      "defaultValue": "Input Tooltip Text"
     },{
     "id": "textfont",
     "label": "Font",
     "type": "FONT_FAMILY",
-    "defaultValue": "auto"
+    "defaultValue": "Arial"
     },{
     "id": "textsize",
     "label": "Text Size",
     "type": "FONT_SIZE",
-    "defaultValue": "10px"
+    "defaultValue": 10
     },{
     "id": "textcolor",
     "label": "Text Color",
@@ -35,7 +36,7 @@
     "id": "borderwidth",
     "label": "Border Width",
     "type": "LINE_WEIGHT",
-    "defaultValue": "1"
+    "defaultValue": 1
     },{
     "id": "borderstyle",
     "label": "Border Style",
@@ -45,7 +46,7 @@
     "id": "borderradius",
     "label": "Border Radius",
     "type": "BORDER_RADIUS",
-    "defaultValue": "0"
+    "defaultValue": 0
     },{
     "id": "backgroundcolor",
     "label": "Background Color",
@@ -62,9 +63,9 @@
       "type": "SELECT_SINGLE",
       "defaultValue": "0",
       "options": [
-        {"label": "Information(i)", "value": 0},
-        {"label": "Question(?)", "value": 1},
-        {"label": "Light Bulb", "value": 2}
+        {"label": "Information(i)", "value": "0"},
+        {"label": "Question(?)", "value": "1"},
+        {"label": "Light Bulb", "value": "2"}
       ]
     },{
       "id": "iconsize",

--- a/ja/mouseovertooltip.json
+++ b/ja/mouseovertooltip.json
@@ -1,7 +1,7 @@
 {
   "data": [{
     "id": "setdummy",
-    "heading": "SetDummyData",
+    "label": "SetDummyData",
     "elements": []
   }],
   "style": [{
@@ -10,17 +10,18 @@
     "elements": [{
       "id": "tooltiptext",
       "label": "テキスト",
-      "type": "TEXTAREA"
+      "type": "TEXTAREA",
+      "defaultValue": "Tooltipに設定する文章を入力"
     },{
     "id": "textfont",
     "label": "フォント",
     "type": "FONT_FAMILY",
-    "defaultValue": "auto"
+    "defaultValue": "Arial"
     },{
     "id": "textsize",
     "label": "テキストサイズ",
     "type": "FONT_SIZE",
-    "defaultValue": "10px"
+    "defaultValue": 10
     },{
     "id": "textcolor",
     "label": "文字色",
@@ -35,7 +36,7 @@
     "id": "borderwidth",
     "label": "ツールチップの枠の太さ",
     "type": "LINE_WEIGHT",
-    "defaultValue": "1"
+    "defaultValue": 1
     },{
     "id": "borderstyle",
     "label": "ツールチップの枠の種類",
@@ -45,7 +46,7 @@
     "id": "borderradius",
     "label": "角を丸くする",
     "type": "BORDER_RADIUS",
-    "defaultValue": "0"
+    "defaultValue": 0
     },{
     "id": "backgroundcolor",
     "label": "ツールチップの背景色",
@@ -62,9 +63,9 @@
       "type": "SELECT_SINGLE",
       "defaultValue": "0",
       "options": [
-        {"label": "インフォメーション（i）マーク", "value": 0},
-        {"label": "クエスチョン（?）マーク", "value": 1},
-        {"label": "ひらめき電球", "value": 2}
+        {"label": "インフォメーション（i）マーク", "value": "0"},
+        {"label": "クエスチョン（?）マーク", "value": "1"},
+        {"label": "ひらめき電球", "value": "2"}
       ]
     },{
       "id": "iconsize",

--- a/js/main.js
+++ b/js/main.js
@@ -12,7 +12,7 @@ function drawViz(data) {
     borderStyle: data.style.borderstyle.value || data.style.borderstyle.defaultValue,
     borderRadius: data.style.borderradius.value || data.style.borderradius.defaultValue,
     iconSize: data.style.iconsize.value || data.style.iconsize.defaultValue,
-    iconColor: data.style.iconcolor.value.color || data.style.iconcolor.defaultValue,
+    iconColor: data.style.iconcolor.value.color /*|| data.style.iconcolor.defaultValue*/,
     backgroundColor: data.style.backgroundcolor.value.color || data.style.backgroundcolor.defaultValue,
     tooltipIcon: data.style.tooltipicon.value || data.style.tooltipicon.defaultValue,
     tooltipText: data.style.tooltiptext.value || data.style.tooltiptext.defaultValue,

--- a/js/main.js
+++ b/js/main.js
@@ -4,21 +4,27 @@ function drawViz(data) {
   const divIcon = document.getElementById("iconDiv");
 
   const st = {
-    textColor: data.style.textcolor.value.color,
-    borderColor: data.style.bordercolor.value.color,
-    textFont: data.style.textfont.value,
-    textSize: data.style.textsize.value,
-    borderWidth: data.style.borderwidth.value,
-    borderStyle: data.style.borderstyle.value,
-    borderRadius: data.style.borderradius.value,
-    iconSize: data.style.iconsize.value,
-    iconColor: data.style.iconcolor.value.color,
-    backgroundColor: data.style.backgroundcolor.value.color,
-    tooltipIcon: data.style.tooltipicon.value,
-    tooltipText: data.style.tooltiptext.value,
+    textColor: data.style.textcolor.value.color || data.style.textcolor.defaultValue,
+    borderColor: data.style.bordercolor.value.color || data.style.bordercolor.defaultValue,
+    textFont: data.style.textfont.value || data.style.textfont.defaultValue,
+    textSize: data.style.textsize.value || data.style.textsize.defaultValue ,
+    borderWidth: data.style.borderwidth.value || data.style.borderwidth.defaultValue,
+    borderStyle: data.style.borderstyle.value || data.style.borderstyle.defaultValue,
+    borderRadius: data.style.borderradius.value || data.style.borderradius.defaultValue,
+    iconSize: data.style.iconsize.value || data.style.iconsize.defaultValue,
+    iconColor: data.style.iconcolor.value.color || data.style.iconcolor.defaultValue,
+    backgroundColor: data.style.backgroundcolor.value.color || data.style.backgroundcolor.defaultValue,
+    tooltipIcon: data.style.tooltipicon.value || data.style.tooltipicon.defaultValue,
+    tooltipText: data.style.tooltiptext.value || data.style.tooltiptext.defaultValue,
   };
 
   //change icon
+  switch(st.tooltipIcon){
+    case "0": divIcon.innerHTML = svgIcons[0]; break;
+    case "1": divIcon.innerHTML = svgIcons[1]; break;
+    case "2": divIcon.innerHTML = svgIcons[2]; break;
+    default: divIcon.innerHTML = svgIcons[0];
+  }
   divIcon.innerHTML = svgIcons[st.tooltipIcon];
 
   //append style


### PR DESCRIPTION
We now support Google Data Studio's Changes to Style Configurations.
https://developers.google.com/datastudio/visualization/changelog#2021-02-10

mouseovertooltip.json
* Change the "heading" attribute of the data setting to the "label" attribute.
* Set defaultValue to TEXTAREA type.
* Change defaultValue of FONT_FAMILY type from auto to Arial.
* Change defaultValue of FONT_SIZE type, LINE_WEIGHT type and BORDER_RADIUS type from STRING to NUMBER.
* Change defaultValue of SELECT_SINGLE type from NUMBER to STRING.

main.js
Since the defaultValue of SELECT_SINGLE type is now STRING instead of NUMBER, we cast numbers of STRING to NUMBER in main.js so that we can control arrays.

Implemented an operation to adjust the default value so that the colour of the icon does not conflict with the colour of the background.