### PR TITLE
Data dimension added to mouseovertooltip.json

### DIFF
--- a/en/mouseovertooltip.json
+++ b/en/mouseovertooltip.json
@@ -2,7 +2,15 @@
   "data": [{
     "id": "setdummy",
     "label": "SetDummyData",
-    "elements": []
+    "elements": [{
+      "type": "DIMENSION",
+      "id": "dummydimension",
+      "label": "Set Dummy Dimension",
+      "options": {
+        "min": 1,
+        "max": 1
+      }
+    }]
   }],
   "style": [{
     "id": "tooltipsetting",

--- a/ja/mouseovertooltip.json
+++ b/ja/mouseovertooltip.json
@@ -2,7 +2,15 @@
   "data": [{
     "id": "setdummy",
     "label": "SetDummyData",
-    "elements": []
+    "elements": [{
+      "type": "DIMENSION",
+      "id": "dummydimension",
+      "label": "Set Dummy Dimension",
+      "options": {
+        "min": 1,
+        "max": 1
+      }
+    }]
   }],
   "style": [{
     "id": "tooltipsetting",


### PR DESCRIPTION
Due to recent changes to Data Studio, visualizations with no data elements are no longer supported.